### PR TITLE
Add cargo-generate template support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+TELOXIDE_TOKEN={{telegram_token}}
+BOT_LANGUAGE={{bot_language}}
+RUN_MODE={{run_mode}}
+WEBHOOK_URL={{webhook_url}}
+WEBHOOK_ADDR={{webhook_addr}}
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ A production-ready template for building Telegram bots with [teloxide](https://g
 - Built-in multilingual greetings (English and Russian).
 - Configuration via environment variables.
 
+## Generating a new project
+
+Use [cargo-generate](https://github.com/cargo-generate/cargo-generate) to
+scaffold a new bot from this template:
+
+```bash
+cargo install cargo-generate # if not already installed
+cargo generate --git https://github.com/your-user/telegram-bot-template
+```
+
+You will be prompted for initial configuration values such as the bot token,
+default language and run mode. The answers populate the generated `.env` file.
+
 ## Configuration
 
 Set the following environment variables before running the bot:

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,28 @@
+[template]
+cargo_generate_version = ">=0.18.0"
+
+[placeholders.telegram_token]
+type = "string"
+prompt = "Bot token from @BotFather"
+default = "000000:TEST"
+
+[placeholders.bot_language]
+type = "string"
+prompt = "Default interface language (en or ru)"
+default = "en"
+
+[placeholders.run_mode]
+type = "string"
+prompt = "Run mode (polling or webhook)"
+default = "polling"
+
+[placeholders.webhook_url]
+type = "string"
+prompt = "Public HTTPS webhook URL"
+default = ""
+
+[placeholders.webhook_addr]
+type = "string"
+prompt = "Webhook bind address"
+default = "0.0.0.0:8443"
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,12 +90,15 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
+    use std::{env, sync::Mutex};
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
     use super::{Config, ConfigError, Language, RunMode};
 
     #[test]
     fn default_config() {
+        let _lock = ENV_MUTEX.lock().expect("lock");
         env::remove_var("BOT_LANGUAGE");
         env::remove_var("RUN_MODE");
         let cfg = Config::from_env().expect("config");
@@ -105,6 +108,7 @@ mod tests {
 
     #[test]
     fn unsupported_language() {
+        let _lock = ENV_MUTEX.lock().expect("lock");
         env::set_var("BOT_LANGUAGE", "de");
         let err = Config::from_env().unwrap_err();
         match err {


### PR DESCRIPTION
## Summary
- document how to scaffold a new project with `cargo generate`
- serialize configuration tests with a mutex to avoid env races
- provide `cargo-generate.toml` and `.env` placeholders for interactive setup

## Testing
- `cargo +nightly fmt --`
- `cargo clippy -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all`
- `cargo doc --no-deps`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68c3b060c1ac832ba68ff5aca3c688a0